### PR TITLE
update `vitesse-black.json` to bump contrast of gitignored files

### DIFF
--- a/themes/vitesse-black.json
+++ b/themes/vitesse-black.json
@@ -149,7 +149,7 @@
     "gitDecoration.modifiedResourceForeground": "#6394bf",
     "gitDecoration.deletedResourceForeground": "#cb7676",
     "gitDecoration.untrackedResourceForeground": "#5eaab5",
-    "gitDecoration.ignoredResourceForeground": "#dedcd530",
+    "gitDecoration.ignoredResourceForeground": "#817878",
     "gitDecoration.conflictingResourceForeground": "#d4976c",
     "gitDecoration.submoduleResourceForeground": "#dedcd590",
     "editorGutter.modifiedBackground": "#6394bf",


### PR DESCRIPTION
# Before
![image](https://user-images.githubusercontent.com/44563205/224536017-71ac9822-4d5b-4243-987c-61157e555556.png)

# After
![image](https://user-images.githubusercontent.com/44563205/224536031-5c8bb3ac-632b-4d2b-8ac6-bd8201c07ef9.png)

I do realised that themes are a personal thing but feel that by default the text should always be readable hence the PR.

Feel free to close it if you don't like it!